### PR TITLE
fix for downloads link returning "page not found"

### DIFF
--- a/docs/Navio-APM/configuring-raspberry-pi.md
+++ b/docs/Navio-APM/configuring-raspberry-pi.md
@@ -2,7 +2,7 @@
 
 Default Raspbian kernel is configured with PREEMPT option and provides worst case latency around single digit milliseconds. Real-time patch with PREEMPT_RT option lowers the worst case latency to tens of microseconds, allowing for better real-time performance useful for autopilots. We have a documentation page dedicated to real-time Linux where you can get more information as well as see the results of performance tests.
 
-We provide an SD card image of Raspbian with fully preemptive real-time Linux kernel. The image is also additionally configured for usage in drone applications. In research purposes you may [use the default Raspbian](Navio-dev/using-default-raspbian) image with additional configuration, but if you’d like to use APM autopilot use only the image we provide in the [downloads](Downloads/Real-time-Linux) section.
+We provide an SD card image of Raspbian with fully preemptive real-time Linux kernel. The image is also additionally configured for usage in drone applications. In research purposes you may [use the default Raspbian](Navio-dev/using-default-raspbian) image with additional configuration, but if you’d like to use APM autopilot use only the image we provide in the [downloads](Downloads/Real-time-Linux-RPi2) section.
 
 
 ####Writing image to SD card


### PR DESCRIPTION
fix for 404

Not Found

The requested URL /Downloads/Real-time-Linux was not found on this server.

Apache/2.4.7 (Ubuntu) Server at docs.emlid.com Port 80
