### PR TITLE
Update documentation to match new SDK version

### DIFF
--- a/docs/Community-projects/Windows-IoT.md
+++ b/docs/Community-projects/Windows-IoT.md
@@ -1,4 +1,4 @@
-#Windows IoT
+# Windows IoT
 
 ----------
 
@@ -14,7 +14,8 @@ All following text is provided by the project author.
 
 ----------
 
-##Project
+
+## Project
 
 In 2015 Microsoft announced official support for the Raspberry Pi 2 running Windows 10 on their new "IoT" (Internet of Things) platform. Soon after work started on an open source SDK for Navio with the following goals:
 
@@ -25,12 +26,14 @@ In 2015 Microsoft announced official support for the Raspberry Pi 2 running Wind
 This document describes how to develop your own code for Navio running on Windows 10 IoT, or just try-out the test and sample apps for yourself. You can follow the progress at the [Emlid forum thread](http://community.emlid.com/t/windows-10-iot-image-for-navio/381/last) or the [Hackster.io project](https://www.hackster.io/team-code-for-robots/navio-sdk-for-windows-iot). If you like it please "respect" the Hackster project to return some kudos to the creator ;-)
 
 
-##Getting Started
+## Getting Started
 
 This section describes how to start development by installing Windows IoT on your device, Visual Studio on your PC, then finally how to clone, build and run the code.
 
 
-###Tools
+### Tools
+
+The "Insider Preview" build 14393 (August 2016) or later is required to run the current SDK. Similarly the Windows 10 "Anniversary Update" (version 1607 build 14393) development kits are required to build it.
 
 Links to download the development tools and basic instructions what to install are provided by Microsoft here:
 
@@ -47,14 +50,14 @@ Since device driver source code has been added to the solution, you will also ne
 [Driver Kit Downloads](https://msdn.microsoft.com/en-US/windows/hardware/dn913721%28v=vs.8.5%29.aspx?f=255&MSPPError=-2147217396)
 
 
-##Development
+## Development
 
 The current Navio SDK "framework" is a Windows Universal library, so can be consumed by any Windows Universal application written in any .NET language supported by IoT. Simply use the NuGet Package Manager of Visual Studio to add the [Emlid.WindowsIot.Hardware](https://www.nuget.org/packages/Emlid.WindowsIoT.Hardware) package, then write some code with the various Navio*Device classes to utilize the hardware.
 
 Deployment is easy with the Visual Studio produced Windows Universal packages. They are precompiled and load directly onto the IoT device. You can deploy them via Visual Studio during development, via the web interface for end users, script them with PowerShell or include them on a preloaded SD card image.
 
 
-###Preparation
+### Preparation
 
 It is strongly recommended you complete some basic training before attempting to build and deploy your first IoT project. Even experienced Windows developers will have to get to grips with some of the special build and deployment requirements for the ARM processor and remote IoT device connections. Also the IoT system is still under early development, even though the desktop Windows 10 builds are finished.
 
@@ -66,7 +69,7 @@ Update the GitHub extension (menu "Tools - Extensions and Updates...").
  5. Select the "Online" tab, search for then install the "Productivity Power Tools 2015" extension.
 
 
-###Building the SDK from Source
+### Building the SDK from Source
 
 1. Click "Team Explorer" then the "Plug" icon (manage connections).
 2. Under "Local Git Repositories" click the "Clone" link then enter the URL of the GitHub project "[https://github.com/emlid/Navio-SDK-Windows-IoT](https://github.com/emlid/Navio-SDK-Windows-IoT)", choose a local path into which the files will be downloaded then the "Clone" button.
@@ -79,10 +82,16 @@ Update the GitHub extension (menu "Tools - Extensions and Updates...").
   ```
 5. On the build toolbar, ensure that "Debug" configuration and "ARM" platform is selected.
 6. In the "Build" menu select "Rebuild Solution". 
-7. Some NuGet packages may be loaded, then the build will start and should complete without any errors.
+7. Some NuGet packages may be loaded, then the build will start.
+8. Once per workstation: Visual Studio requires that the temporary signing keys are installed in a per-machine unique "VS_KEY_HHHHHHHHHHHHHHHH" container. Copy the container name from the error message, open a command prompt at the solution folder then run the following commands (with your unique VS_KEY value):
+  ```
+  cd Common
+  "TemporaryKey Install.cmd" VS_KEY_HHHHHHHHHHHHHHHH
+  ```
+9. Rebuild the solution, it should now complete without any errors.
 
 
-###Build and Run the Hardware Test App
+### Build and Run the Hardware Test App
 
 The Hardware Test app is currently only distributed as source. Later it will also be available for stand-alone use (without any development tools).
 
@@ -97,7 +106,7 @@ The Hardware Test app is currently only distributed as source. Later it will als
 9. Click "Close" then "Exit" to finish.
 
 
-###Build and Run the Samples
+### Build and Run the Samples
 
 Currently the sample applications are "Background Application" projects, which means they run directly from Visual Studio with no UI. All output is sent back via debug messages to the Visual Studio "Output" window.
 
@@ -112,8 +121,9 @@ Monitor the output window for any messages, and look at the physical device for 
 
 ## Known Issues
 
-1. Since Update 1 and IoT build 10586 it is necessary to manually start the remote debugging tools via the web interface before deployment will be successful. Also the remote machine name must be edited to include the port of the remote debugger, which appears in the confirmation dialog when starting them via the web interface, e.g. MyDeviceName:8116.
-2. RC Input is super slow because we are in the middle of conversion to C++ and drivers. Software decoding is too slow and unreliable in user mode on the Raspberry Pi, so it is delayed until after all the other components are implemented. Navio2 may be supported first because it has decoding hardware.
+1. The "Insider Preview" build is required.
+2. RC Input is not currently usable because of issues with both the standard "inbox" and "lightning" GPIO provider. Microsoft are providing new features in an upcoming release which may make this possible. The long term goal is to convert to C++ and drivers. Software decoding is too slow and unreliable in user mode on the Raspberry Pi, so it is delayed until after all the other components are implemented. Navio2 may be supported first because it has decoding hardware.
+3. Deployment/debugging will sometimes fail with protocol errors or not found, even when it is confiured correctly. Try again, if you can see the device in the IoT Dashboard it should work. 
 
 
 ## Roadmap
@@ -166,6 +176,17 @@ Mission statement: "Expand support and add new devices."
 
 
 ## Change Log
+
+*2016.08.24* v1.0.8
+
+1. Updated solution to Visual Studio 2015 Update 3 and Windows 10 SDK and WDK version 1607 build 10.0.14393.
+2. Support new Microsoft Lightning provider v1.1.0 for faster hardware access. Now referenced via NuGet package, removing the need for manually built dependencies.
+3. Updated .NET Core SDK package to current 5.2.2.
+4. Refactored harwdare source into separate subdirectories/namespaces so it is easier to manage and use.
+5. Addressed some minor bugs in the GUI.
+6. General refactoring and tidy-up.
+7. Improved setup scripts and instructions.
+
 
 *2016.01.02* v1.0.7
 


### PR DESCRIPTION
Note: according to the Markdown documentation and tools used to edit these files, a space is required after the hash of opening headings. I have implemented those few edits so I can effectively edit them in my tools. Hopefully that does not conflict with any Linux markdown tools used on the Emlid web site / developer PCs. See: https://en.support.wordpress.com/markdown-quick-reference/
